### PR TITLE
fix: serialize ScoreState as Object instead of Map

### DIFF
--- a/src/score_state.rs
+++ b/src/score_state.rs
@@ -136,11 +136,9 @@ impl JsScoreState {
 impl From<ScoreState> for JsScoreState {
     fn from(state: ScoreState) -> Self {
         let obj = js_sys::Object::new();
+        let obj_as_ext = obj.unchecked_ref::<util::ObjectExt>();
 
-        let set = |key, value: u32| {
-            obj.unchecked_ref::<util::ObjectExt>()
-                .set(util::static_str_to_js(key), value.into())
-        };
+        let set = |key, value: u32| obj_as_ext.set(util::static_str_to_js(key), value.into());
 
         set("maxCombo", state.max_combo);
         set("nGeki", state.n_geki);

--- a/src/score_state.rs
+++ b/src/score_state.rs
@@ -135,15 +135,21 @@ impl JsScoreState {
 
 impl From<ScoreState> for JsScoreState {
     fn from(state: ScoreState) -> Self {
-        let map = js_sys::Map::new();
-        map.set(&util::static_str_to_js("maxCombo"), &state.max_combo.into());
-        map.set(&util::static_str_to_js("nGeki"), &state.n_geki.into());
-        map.set(&util::static_str_to_js("nKatu"), &state.n_katu.into());
-        map.set(&util::static_str_to_js("n300"), &state.n300.into());
-        map.set(&util::static_str_to_js("n100"), &state.n100.into());
-        map.set(&util::static_str_to_js("n50"), &state.n50.into());
-        map.set(&util::static_str_to_js("misses"), &state.misses.into());
+        let obj = js_sys::Object::new();
 
-        JsValue::from(map).into()
+        let set = |key, value: u32| {
+            obj.unchecked_ref::<util::ObjectExt>()
+                .set(util::static_str_to_js(key), value.into())
+        };
+
+        set("maxCombo", state.max_combo);
+        set("nGeki", state.n_geki);
+        set("nKatu", state.n_katu);
+        set("n300", state.n300);
+        set("n100", state.n100);
+        set("n50", state.n50);
+        set("misses", state.misses);
+
+        JsValue::from(obj).into()
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,7 +23,7 @@ extern "C" {
     pub fn get_with_ref_key(this: &ObjectExt, key: &JsString) -> JsValue;
 
     #[wasm_bindgen(method, indexing_setter)]
-    fn set(this: &ObjectExt, key: JsString, value: JsValue);
+    pub fn set(this: &ObjectExt, key: JsString, value: JsValue);
 }
 
 /// Store converted strings and return clones instead of converting them


### PR DESCRIPTION
This adds proper serialization of `ScoreState` for `PerformanceAttributes`.
Using `js_sys::Map` didn't work for some reason so now a `js_sys::Object` is used instead.