### PR TITLE
feat: use rosu-mods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,12 +70,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c55926c8f0fed1db12fbe96f7a6083a2c4186443dd32532ab34e6902467a4f3"
 
 [[package]]
-name = "rosu-pp"
-version = "1.0.0"
+name = "rosu-mods"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f146c66bed5900ee1fa2b55ef5cc5dd2dbd45e6cac0f7bee5cae535980afbc"
+checksum = "d69daf02885f7477085403a6eada6215f44333c7b54355ea1c4e276a02263bde"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "rosu-pp"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002a6b12cedcb185f4051f0b3d0466e0b61ff414a9ca8375f09be581c0e70f06"
 dependencies = [
  "rosu-map",
+ "rosu-mods",
 ]
 
 [[package]]
@@ -83,6 +93,7 @@ name = "rosu-pp-js"
 version = "1.0.2"
 dependencies = [
  "js-sys",
+ "rosu-mods",
  "rosu-pp",
  "serde",
  "wasm-bindgen",
@@ -97,18 +108,18 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 js-sys = "0.3.69"
+rosu-mods = { version = "0.1.0", default-features = false, features = ["serde"] }
 rosu-pp = "1.0.0"
 serde = { version = "1.0.197", features = ["derive"] }
 wasm-bindgen = "0.2.84"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 js-sys = "0.3.69"
 rosu-mods = { version = "0.1.0", default-features = false, features = ["serde"] }
-rosu-pp = "1.0.0"
+rosu-pp = "1.1.0"
 serde = { version = "1.0.197", features = ["derive"] }
 wasm-bindgen = "0.2.84"
 

--- a/rosu_pp_js.d.ts
+++ b/rosu_pp_js.d.ts
@@ -421,7 +421,7 @@ export class BeatmapAttributesBuilder {
   mode?: GameMode;
 /**
 */
-  mods?: number;
+  mods?: Object;
 /**
 */
   od?: number;
@@ -492,7 +492,7 @@ export class Difficulty {
   hpWithMods?: boolean;
 /**
 */
-  mods?: number;
+  mods?: Object;
 /**
 */
   od?: number;
@@ -785,7 +785,7 @@ export class Performance {
   misses?: number;
 /**
 */
-  mods?: number;
+  mods?: Object;
 /**
 */
   n100?: number;

--- a/rosu_pp_js.d.ts
+++ b/rosu_pp_js.d.ts
@@ -49,11 +49,25 @@ export interface BeatmapAttributesArgs extends CommonArgs {
 */
 export interface CommonArgs {
     /**
-    * Specify mods through their bit values.
+    * Specify mods.
+    *
+    * The type must be either
+    *   - an integer for bitflags
+    *   - a string for acronyms
+    *   - a single mod object as described below
+    *   - a sequence of types that deserialize into a single mod
+    *
+    * Types that deserialize into a single mod are
+    *   - an integer for bitflags
+    *   - a string for an acronym
+    *   - a mod object
+    *
+    * A mod object must have an `acronym: string` property and an optional
+    * `settings?: Object` property.
     *
     * See <https://github.com/ppy/osu-api/wiki#mods>
     */
-    mods?: number;
+    mods?: Object;
     /**
     * Adjust the clock rate used in the calculation.
     *

--- a/src/args/common.rs
+++ b/src/args/common.rs
@@ -6,11 +6,25 @@ const _: &'static str = r#"/**
 */
 export interface CommonArgs {
     /**
-    * Specify mods through their bit values.
+    * Specify mods.
+    *
+    * The type must be either
+    *   - an integer for bitflags
+    *   - a string for acronyms
+    *   - a single mod object as described below
+    *   - a sequence of types that deserialize into a single mod
+    *
+    * Types that deserialize into a single mod are
+    *   - an integer for bitflags
+    *   - a string for an acronym
+    *   - a mod object
+    *
+    * A mod object must have an `acronym: string` property and an optional
+    * `settings?: Object` property.
     *
     * See <https://github.com/ppy/osu-api/wiki#mods>
     */
-    mods?: number;
+    mods?: Object;
     /**
     * Adjust the clock rate used in the calculation.
     *

--- a/src/args/performance.rs
+++ b/src/args/performance.rs
@@ -1,3 +1,4 @@
+use rosu_mods::GameMods;
 use rosu_pp::{
     any::{DifficultyAttributes, HitResultPriority},
     Performance,
@@ -80,8 +81,8 @@ export interface PerformanceArgs extends DifficultyArgs {
 #[derive(Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase", rename = "Object")]
 pub struct PerformanceArgs {
-    #[serde(default)]
-    pub mods: u32,
+    #[serde(default, deserialize_with = "util::deserialize_mods")]
+    pub mods: GameMods,
     pub clock_rate: Option<f64>,
     pub ar: Option<f32>,
     #[serde(default)]
@@ -175,7 +176,7 @@ impl PerformanceArgs {
         }
 
         let difficulty = DifficultyArgs {
-            mods: self.mods,
+            mods: self.mods.clone(),
             clock_rate: self.clock_rate,
             ar: self.ar,
             ar_with_mods: self.ar_with_mods,
@@ -190,7 +191,7 @@ impl PerformanceArgs {
         };
 
         perf.hitresult_priority(self.hitresult_priority)
-            .difficulty(difficulty.as_difficulty())
+            .difficulty(difficulty.to_difficulty())
     }
 }
 

--- a/src/attributes/beatmap.rs
+++ b/src/attributes/beatmap.rs
@@ -6,6 +6,7 @@ use crate::{
     beatmap::JsBeatmap,
     deserializer::JsDeserializer,
     mode::JsGameMode,
+    mods::JsGameMods,
     util, JsResult,
 };
 
@@ -40,8 +41,15 @@ impl JsBeatmapAttributesBuilder {
     }
 
     #[wasm_bindgen(setter)]
-    pub fn set_mods(&mut self, mods: Option<u32>) {
-        self.args.mods = mods.unwrap_or_default();
+    pub fn set_mods(&mut self, mods: Option<JsGameMods>) -> JsResult<()> {
+        self.args.mods = mods
+            .as_deref()
+            .map(JsDeserializer::from_ref)
+            .map(util::deserialize_mods)
+            .transpose()?
+            .unwrap_or_default();
+
+        Ok(())
     }
 
     #[wasm_bindgen(setter = clockRate)]

--- a/src/gradual/difficulty.rs
+++ b/src/gradual/difficulty.rs
@@ -16,7 +16,7 @@ impl JsGradualDifficulty {
     #[wasm_bindgen(constructor)]
     pub fn new(difficulty: &JsDifficulty, map: &JsBeatmap) -> JsGradualDifficulty {
         Self {
-            inner: GradualDifficulty::new(difficulty.args.as_difficulty(), &map.inner),
+            inner: GradualDifficulty::new(difficulty.args.to_difficulty(), &map.inner),
         }
     }
 

--- a/src/gradual/performance.rs
+++ b/src/gradual/performance.rs
@@ -18,7 +18,7 @@ impl JsGradualPerformance {
     #[wasm_bindgen(constructor)]
     pub fn new(difficulty: &JsDifficulty, map: &JsBeatmap) -> JsGradualPerformance {
         Self {
-            inner: GradualPerformance::new(difficulty.args.as_difficulty(), &map.inner),
+            inner: GradualPerformance::new(difficulty.args.to_difficulty(), &map.inner),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod difficulty;
 mod error;
 mod gradual;
 mod mode;
+mod mods;
 mod performance;
 mod score_state;
 mod strains;

--- a/src/mods.rs
+++ b/src/mods.rs
@@ -1,0 +1,7 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = Object)]
+    pub type JsGameMods;
+}

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -6,6 +6,8 @@ use crate::{
         JsHitResultPriority, JsMapOrAttributes, JsPerformanceArgs, MapOrAttrs, PerformanceArgs,
     },
     attributes::performance::JsPerformanceAttributes,
+    deserializer::JsDeserializer,
+    mods::JsGameMods,
     util, JsResult,
 };
 
@@ -63,8 +65,15 @@ impl JsPerformance {
     }
 
     #[wasm_bindgen(setter)]
-    pub fn set_mods(&mut self, mods: Option<u32>) {
-        self.args.mods = mods.unwrap_or_default();
+    pub fn set_mods(&mut self, mods: Option<JsGameMods>) -> JsResult<()> {
+        self.args.mods = mods
+            .as_deref()
+            .map(JsDeserializer::from_ref)
+            .map(util::deserialize_mods)
+            .transpose()?
+            .unwrap_or_default();
+
+        Ok(())
     }
 
     #[wasm_bindgen(setter = clockRate)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,11 @@ use std::{
 };
 
 use js_sys::JsString;
-use serde::de;
+use rosu_mods::{serde::GameModsSeed, GameMods};
+use serde::{
+    de::{self, DeserializeSeed},
+    Deserializer,
+};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 use crate::JsResult;
@@ -91,4 +95,8 @@ impl<'de> de::Visitor<'de> for FieldVisitor {
 
         Err(de::Error::invalid_value(de::Unexpected::Str(v), &self))
     }
+}
+
+pub fn deserialize_mods<'de, 'a, D: Deserializer<'de>>(d: D) -> Result<GameMods, D::Error> {
+    DeserializeSeed::deserialize(GameModsSeed::AllowMultipleModes, d)
 }


### PR DESCRIPTION
Bump `rosu-pp` to `v1.1.0` which utilizes `rosu-mods` to pass mods as arguments. 

Instead of the binding only allowing the `number` type for mods, now the type must be either
  - an integer for bitflags
  - a string for acronyms
  - a single mod object as described below
  - a sequence of types that deserialize into a single mod

Types that deserialize into a single mod are
  - an integer for bitflags
  - a string for an acronym
  - a mod object

A mod object must have an `acronym: string` property and an optional `settings?: Object` property.

Conveniently, this definition includes the JSON structure of mods as returned by the osu!api.