### PR TITLE
Preserve error data on throws

### DIFF
--- a/src/args/performance.rs
+++ b/src/args/performance.rs
@@ -222,7 +222,7 @@ impl MapOrAttrs {
             return Ok(Self::Map(map));
         }
 
-        Err(JsError::from(
+        Err(JsError::new(
             "Expected either previously calculated attributes or a beatmap",
         ))
     }

--- a/src/attributes/difficulty.rs
+++ b/src/attributes/difficulty.rs
@@ -371,6 +371,6 @@ impl TryFrom<JsDifficultyAttributes> for DifficultyAttributes {
             }
         }
 
-        Err(JsError::from("invalid difficulty attributes"))
+        Err(JsError::new("invalid difficulty attributes"))
     }
 }

--- a/src/beatmap.rs
+++ b/src/beatmap.rs
@@ -49,7 +49,7 @@ impl JsBeatmap {
                     e = src;
                 }
 
-                Err(JsError::new(content))
+                Err(JsError::new(&content))
             }
         }
     }
@@ -60,7 +60,7 @@ impl JsBeatmap {
         let mode = GameMode::from(mode);
 
         if let ConvertStatus::Incompatible = self.inner.convert_in_place(mode) {
-            return Err(JsError::new(format!(
+            return Err(JsError::new(&format!(
                 "Cannot convert {:?} to {mode:?}",
                 self.inner.mode
             )));

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -292,7 +292,7 @@ impl<'de, 'js> de::Deserializer<'de> for JsDeserializer<'js> {
             .is_some_and(|name| name == struct_name);
 
         if !correct_classname {
-            return Err(JsError::new(format!("Expected {struct_name}")));
+            return Err(JsError::new(&format!("Expected {struct_name}")));
         }
 
         visitor.visit_map(ObjectAccess::new(obj, fields))

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,46 +3,32 @@ use std::{error, fmt};
 use serde::de;
 use wasm_bindgen::prelude::*;
 
-use crate::util;
-
 pub type JsResult<T> = Result<T, JsError>;
 
 #[derive(Debug)]
-pub struct JsError(JsValue);
+pub struct JsError(js_sys::Error);
 
 impl JsError {
-    pub fn new(err: String) -> Self {
-        Self(err.into())
-    }
-}
-
-impl From<&'static str> for JsError {
-    fn from(err: &'static str) -> Self {
-        Self(util::static_str_to_js(err).into())
+    pub fn new(msg: &str) -> Self {
+        Self(js_sys::Error::new(msg))
     }
 }
 
 impl From<JsValue> for JsError {
     fn from(value: JsValue) -> Self {
-        Self(value)
+        Self(value.into())
     }
 }
 
 impl From<JsError> for JsValue {
-    fn from(JsError(value): JsError) -> Self {
-        value
+    fn from(JsError(err): JsError) -> Self {
+        err.into()
     }
 }
 
 impl fmt::Display for JsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        #[wasm_bindgen]
-        extern "C" {
-            #[wasm_bindgen(js_name = String)]
-            pub fn to_string(value: &JsValue) -> String;
-        }
-
-        to_string(&self.0).fmt(f)
+        self.0.to_string().fmt(f)
     }
 }
 
@@ -50,6 +36,6 @@ impl error::Error for JsError {}
 
 impl de::Error for JsError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        JsError::new(msg.to_string())
+        JsError::new(&msg.to_string())
     }
 }


### PR DESCRIPTION
Closes #18 

Thrown errors are now formatted the same way as they are in js itself.