### PR TITLE
fix!: consume BeatmapAttributesBuilder on build

### DIFF
--- a/src/args/beatmap.rs
+++ b/src/args/beatmap.rs
@@ -104,7 +104,7 @@ pub struct BeatmapAttributesArgs {
 }
 
 impl BeatmapAttributesArgs {
-    pub fn as_builder(&self) -> BeatmapAttributesBuilder {
+    pub fn into_builder(self) -> BeatmapAttributesBuilder {
         let mut builder = BeatmapAttributesBuilder::new();
 
         if let Some(ref map) = self.map {
@@ -137,7 +137,7 @@ impl BeatmapAttributesArgs {
 
         match self.mods.checked_bits() {
             Some(bits) => builder.mods(bits),
-            None => builder.mods(self.mods.clone()),
+            None => builder.mods(self.mods),
         }
     }
 }

--- a/src/attributes/beatmap.rs
+++ b/src/attributes/beatmap.rs
@@ -36,8 +36,8 @@ impl JsBeatmapAttributesBuilder {
     }
 
     /// Calculate the `BeatmapAttributes`.
-    pub fn build(&self) -> JsBeatmapAttributes {
-        self.args.as_builder().build().into()
+    pub fn build(self) -> JsBeatmapAttributes {
+        self.args.into_builder().build().into()
     }
 
     #[wasm_bindgen(setter)]


### PR DESCRIPTION
Turns out #22 was only a band-aid for an underlying issue.

Passing a `Beatmap` to `BeatmapAttributesBuilder` would make the builder hold onto it even after `build` is called, meaning the map would still be marked as used. This is because `build` does not consume the builder to allow for re-use.

This PR makes `build` take ownership of the builder, causing future interactions with that same builder instance to fail with `"null pointer passed to rust"`. Since ownership is taken, returning from `build` will drop `self` and all its fields, including the beatmap, causing it to no longer be marked as used.

Until a version containing this fix is released (which will be `v2.0.0`), there is an available workaround:
- Creating a `BeatmapAttributesBuilder` and storing it in a variable
- Calling `.build()` on that variable
- Explicitly freeing the builder.

```js
const builder = new rosu.BeatmapAttributesBuilder({
  map: my_beatmap,
  mods: my_mods,
});
const attributes = builder.build();
builder.free(); // <-

// now map can be free'd too
my_beatmap.free();
```