### PR TITLE
fix: dont check type names when deserializing

### DIFF
--- a/src/attributes/performance.rs
+++ b/src/attributes/performance.rs
@@ -100,7 +100,9 @@ impl JsPerformanceAttributes {
             }
 
             fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-                map.next_key::<DifficultyField>()?;
+                if map.next_key::<DifficultyField>()?.is_none() {
+                    return Err(de::Error::missing_field(DifficultyField::NAME));
+                }
 
                 map.next_value::<JsDifficultyAttributes>()
             }

--- a/src/beatmap.rs
+++ b/src/beatmap.rs
@@ -154,7 +154,9 @@ impl JsBeatmap {
             }
 
             fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-                map.next_key::<BeatmapField>()?;
+                if map.next_key::<BeatmapField>()?.is_none() {
+                    return Err(de::Error::custom("expected a Beatmap"));
+                }
 
                 let ptr_u32 = map.next_value::<u32>()?;
                 let instance_ref = unsafe { JsBeatmap::ref_from_abi(ptr_u32) };

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use js_sys::{Array, Number, Object, Reflect, Uint8Array};
+use js_sys::{Array, Number, Object, Uint8Array};
 use serde::de::{
     self,
     value::{MapDeserializer, SeqDeserializer},
@@ -275,7 +275,7 @@ impl<'de, 'js> de::Deserializer<'de> for JsDeserializer<'js> {
 
     fn deserialize_struct<V: de::Visitor<'de>>(
         self,
-        struct_name: &'static str,
+        _struct_name: &'static str,
         fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
@@ -284,16 +284,6 @@ impl<'de, 'js> de::Deserializer<'de> for JsDeserializer<'js> {
         } else {
             return self.invalid_type(visitor);
         };
-
-        let constructor = Reflect::get(&self.value, &util::static_str_to_js("constructor").into())?;
-
-        let correct_classname = Reflect::get(&constructor, &util::static_str_to_js("name").into())?
-            .as_string()
-            .is_some_and(|name| name == struct_name);
-
-        if !correct_classname {
-            return Err(JsError::new(&format!("Expected {struct_name}")));
-        }
 
         visitor.visit_map(ObjectAccess::new(obj, fields))
     }


### PR DESCRIPTION
Deserialization no longer validates the type name and instead errors if required fields are missing. This allows users to provide custom or renamed types as long as the fields match.